### PR TITLE
deleted asm nop

### DIFF
--- a/basic-tests/if.cpp
+++ b/basic-tests/if.cpp
@@ -42,9 +42,7 @@ int main() {
       }
     }
   }
-
-	asm("nop"); // TODO (se-passau/VaRA#296): Workaround for false region detection
-
+  
   ___REGION_END __RT_High "0"
 
   return 0;


### PR DESCRIPTION
Issue se-passau/VaRA#296 is closed, therefore the workaround asm("nop") is no longer needed.